### PR TITLE
Fix date range names

### DIFF
--- a/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_Extremes_Inundation/Scenario_A_Extreme_Water_Level.ipynb
+++ b/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_Extremes_Inundation/Scenario_A_Extreme_Water_Level.ipynb
@@ -938,7 +938,7 @@
      "collapsed": false,
      "input": [
       "# Create time index for model DataFrame\n",
-      "ts_rng = pd.date_filter(start=jd_start, end=jd_stop, freq='6Min')\n",
+      "ts_rng = pd.date_range(start=jd_start, end=jd_stop, freq='6Min')\n",
       "ts = pd.DataFrame(index=ts_rng)\n",
       "\n",
       "#Get the station lat/lon into lists and create list of model DataFrames for each station\n",

--- a/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_Extremes_Inundation/Scenario_A_Extreme_Water_Level.py
+++ b/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_Extremes_Inundation/Scenario_A_Extreme_Water_Level.py
@@ -409,7 +409,7 @@ constraint = iris.Constraint(cube_func=name_in_list)
 # <codecell>
 
 # Create time index for model DataFrame
-ts_rng = pd.date_filter(start=jd_start, end=jd_stop, freq='6Min')
+ts_rng = pd.date_range(start=jd_start, end=jd_stop, freq='6Min')
 ts = pd.DataFrame(index=ts_rng)
 
 #Get the station lat/lon into lists and create list of model DataFrames for each station

--- a/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_ModelDataCompare_Currents/Scenario_2A_Model_Obs_Compare_Currents.ipynb
+++ b/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_ModelDataCompare_Currents/Scenario_2A_Model_Obs_Compare_Currents.ipynb
@@ -1048,7 +1048,7 @@
      "collapsed": false,
      "input": [
       "# # Create time index for model DataFrame\n",
-      "ts_rng = pd.date_filter(start=jd_start, end=jd_stop, freq='6Min')\n",
+      "ts_rng = pd.date_range(start=jd_start, end=jd_stop, freq='6Min')\n",
       "ts = pd.DataFrame(index=ts_rng)\n",
       "\n",
       "# Create list of model DataFrames for each station\n",

--- a/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_ModelDataCompare_Currents/Scenario_2A_Model_Obs_Compare_Currents.py
+++ b/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_ModelDataCompare_Currents/Scenario_2A_Model_Obs_Compare_Currents.py
@@ -322,7 +322,7 @@ v_constraint = iris.Constraint(cube_func=name_in_list)
 # <codecell>
 
 # # Create time index for model DataFrame
-ts_rng = pd.date_filter(start=jd_start, end=jd_stop, freq='6Min')
+ts_rng = pd.date_range(start=jd_start, end=jd_stop, freq='6Min')
 ts = pd.DataFrame(index=ts_rng)
 
 # Create list of model DataFrames for each station

--- a/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_ModelDataCompare_Waves/Scenario_A_Model_Obs_Compare_Waves.ipynb
+++ b/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_ModelDataCompare_Waves/Scenario_A_Model_Obs_Compare_Waves.ipynb
@@ -670,7 +670,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "ts_rng = pd.date_filter(start=start_date, end=end_date)\n",
+      "ts_rng = pd.date_range(start=start_date, end=end_date)\n",
       "ts = pd.DataFrame(index=ts_rng)\n",
       "\n",
       "Hs_obs_df = []\n",

--- a/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_ModelDataCompare_Waves/Scenario_A_Model_Obs_Compare_Waves.py
+++ b/Theme_2_Extreme_Events/Scenario_2A_Coastal_Inundation/Scenario_2A_ModelDataCompare_Waves/Scenario_A_Model_Obs_Compare_Waves.py
@@ -200,7 +200,7 @@ obs_lat = [sta for sta in obs_loc_df['latitude (degree)']]
 
 # <codecell>
 
-ts_rng = pd.date_filter(start=start_date, end=end_date)
+ts_rng = pd.date_range(start=start_date, end=end_date)
 ts = pd.DataFrame(index=ts_rng)
 
 Hs_obs_df = []


### PR DESCRIPTION
Substitution replaced `pd.date_range` when changing `date_range` and `dateRange` functions.  This will revert the pandas functions back to a properly functioning state.
