### PR TITLE
Fix test to reflect new directory.

### DIFF
--- a/housekeeping/test/test_system-test_rules.py
+++ b/housekeeping/test/test_system-test_rules.py
@@ -19,7 +19,7 @@ import unittest
 class RunNotebooks(unittest.TestCase):
     def setUp(self):
         files = []
-        path = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
+        path = os.path.abspath(os.path.join(os.getcwd(), os.pardir, os.pardir))
         for root, dirs, fnames in os.walk(path):
             for fname in fnames:
                 if fname.endswith(".ipynb"):


### PR DESCRIPTION
And now travis-ci should be back running `housekeeping/test/test_system-test_rules.py`.
