### PR TITLE
Rename ENV

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: SIT
+name: ioos-blog
 channels:
   - ioos
 dependencies:


### PR DESCRIPTION
Following @rsignell-usgs suggestions I am renaming from `SIT` to `ioos-blog`.